### PR TITLE
Tiny fix for builds without TB_IMAGE setup

### DIFF
--- a/src/tb/tb_core.cpp
+++ b/src/tb/tb_core.cpp
@@ -34,7 +34,11 @@ bool tb_core_init(TBRenderer *renderer)
 	g_image_manager = new TBImageManager();
 #endif
 	return renderer && g_tb_lng && g_font_manager && g_tb_skin
-		&& g_widgets_reader && g_image_manager;
+		&& g_widgets_reader
+#ifdef TB_IMAGE
+		&& g_image_manager
+#endif
+;
 }
 
 void tb_core_shutdown()


### PR DESCRIPTION
Building with `TB_IMAGE` set to `OFF` is producing a compilation error:
```
error: ‘g_image_manager’ was not declared in this scope
   && g_widgets_reader && g_image_manager;
                          ^~~~~~~~~~~~~~~
```
`g_image_manager` is not defined but used inside the boolean expression in the file `tb_core.cpp`.

This error is easy to reproduce by only setting `TB_IMAGE` to `OFF`.
Working Environment: Linux  4.15.0-45-generic #48-Ubuntu SMP x86_64 x86_64 x86_64 GNU/Linux
Build: g++ (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
