### PR TITLE
Adding sys/auxv.h back to main.cpp to fix missing getauxval and AT_EXECFN

### DIFF
--- a/Demo/platform/main.cpp
+++ b/Demo/platform/main.cpp
@@ -13,7 +13,7 @@
 #endif
 #ifdef TB_SYSTEM_LINUX
 #include <unistd.h>
-//#include <sys/auxv.h>
+#include <sys/auxv.h>
 #endif
 #ifdef TB_SYSTEM_WINDOWS
 #include <tchar.h>

--- a/Demo/platform/main.cpp
+++ b/Demo/platform/main.cpp
@@ -13,7 +13,9 @@
 #endif
 #ifdef TB_SYSTEM_LINUX
 #include <unistd.h>
+#if !defined(__EMSCRIPTEN__)
 #include <sys/auxv.h>
+#endif
 #endif
 #ifdef TB_SYSTEM_WINDOWS
 #include <tchar.h>


### PR DESCRIPTION
Fixes an error when trying to compile the demo on linux:

```
turbobadger/Demo/platform/main.cpp: In Funktion »bool port_main(int, char**)«:
turbobadger/Demo/platform/main.cpp:72:23: Fehler: »AT_EXECFN« wurde in diesem Gültigkeitsbereich nicht definiert
   72 |         if (getauxval(AT_EXECFN))
      |                       ^~~~~~~~~
turbobadger/Demo/platform/main.cpp:72:13: Fehler: »getauxval« wurde in diesem Gültigkeitsbereich nicht definiert
   72 |         if (getauxval(AT_EXECFN))
      |             ^~~~~~~~~
```